### PR TITLE
Update getting started to zeebe version 1.1.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
     zeebe:
-        image: camunda/zeebe:${CAMUNDA_CLOUD_VERSION:-1.0.1}
+        image: camunda/zeebe:${CAMUNDA_CLOUD_VERSION:-1.1.0}
         container_name: zeebe
         environment:
             - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME=io.camunda.zeebe.exporter.ElasticsearchExporter
@@ -18,7 +18,7 @@ services:
             - elasticsearch
 
     operate:
-        image: camunda/operate:${CAMUNDA_CLOUD_VERSION:-1.0.1}
+        image: camunda/operate:${CAMUNDA_CLOUD_VERSION:-1.1.0}
         container_name: operate
         environment:
             - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
@@ -32,7 +32,7 @@ services:
             - elasticsearch
 
     tasklist:
-        image: camunda/tasklist:${CAMUNDA_CLOUD_VERSION:-1.0.1}
+        image: camunda/tasklist:${CAMUNDA_CLOUD_VERSION:-1.1.0}
         container_name: tasklist
         environment:
             - CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS=zeebe:26500

--- a/java/README.md
+++ b/java/README.md
@@ -13,7 +13,7 @@ provides a Zeebe client.
 <dependency>
 	<groupId>io.camunda</groupId>
 	<artifactId>zeebe-client-java</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 </dependency>
 ```
 

--- a/java/README.md
+++ b/java/README.md
@@ -32,6 +32,7 @@ ZeebeClient client = ZeebeClient.newCloudClientBuilder()
         .withClusterId("365eed98-16c1-4096-bb57-eb8828ed131e")
         .withClientId("GZVO3ALYy~qCcD3MYq~sf0GIszNzLE_z")
         .withClientSecret(".RPbZc6q0d6uzRbB4LW.B8lCpsxbBEpmBX0AHQGzINf3.KK9RkzZW1aDaZ-7WYNJ")
+        .withRegion("bru-2")
         .build()
 ```
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <zeebe.version>1.0.1</zeebe.version>
+    <zeebe.version>1.1.0</zeebe.version>
     <log4j.version>2.14.1</log4j.version>
     <main.class>io.camunda.getstarted.DeployAndStartInstance</main.class>
   </properties>

--- a/java/src/main/java/io/camunda/getstarted/ZeebeClientFactory.java
+++ b/java/src/main/java/io/camunda/getstarted/ZeebeClientFactory.java
@@ -9,6 +9,7 @@ public class ZeebeClientFactory {
         .withClusterId("365eed98-16c1-4096-bb57-eb8828ed131e")
         .withClientId("GZVO3ALYy~qCcD3MYq~sf0GIszNzLE_z")
         .withClientSecret(".RPbZc6q0d6uzRbB4LW.B8lCpsxbBEpmBX0AHQGzINf3.KK9RkzZW1aDaZ-7WYNJ")
+        .withRegion("bru-2")
         .build();
   }
 


### PR DESCRIPTION
Updates dependencies to Zeebe version 1.1.0 for components where available (java, spring, docker).

In addition, for java it offers users the default region as an easy to replace property.