### PR TITLE
Bump zeebe to 1.3.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
     zeebe:
-        image: camunda/zeebe:${CAMUNDA_CLOUD_VERSION:-1.2.7}
+        image: camunda/zeebe:${CAMUNDA_CLOUD_VERSION:-1.3.0}
         container_name: zeebe
         environment:
             - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME=io.camunda.zeebe.exporter.ElasticsearchExporter
@@ -18,7 +18,7 @@ services:
             - elasticsearch
 
     operate:
-        image: camunda/operate:${CAMUNDA_CLOUD_VERSION:-1.2.7}
+        image: camunda/operate:${CAMUNDA_CLOUD_VERSION:-1.3.0}
         container_name: operate
         environment:
             - CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=zeebe:26500
@@ -32,7 +32,7 @@ services:
             - elasticsearch
 
     tasklist:
-        image: camunda/tasklist:${CAMUNDA_CLOUD_VERSION:-1.2.7}
+        image: camunda/tasklist:${CAMUNDA_CLOUD_VERSION:-1.3.0}
         container_name: tasklist
         environment:
             - CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS=zeebe:26500

--- a/java/README.md
+++ b/java/README.md
@@ -13,7 +13,7 @@ provides a Zeebe client.
 <dependency>
 	<groupId>io.camunda</groupId>
 	<artifactId>zeebe-client-java</artifactId>
-	<version>1.2.7</version>
+	<version>1.3.0</version>
 </dependency>
 ```
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <zeebe.version>1.2.7</zeebe.version>
+    <zeebe.version>1.3.0</zeebe.version>
     <log4j.version>2.17.1</log4j.version>
     <main.class>io.camunda.getstarted.DeployAndStartInstance</main.class>
   </properties>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<zeebe.version>1.2.7</zeebe.version>
+		<zeebe.version>1.3.0</zeebe.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Bumps the Zeebe versions defined in the README, poms and docker-compose files to the latest version 1.3.0.

This is part of the [release protocol](https://github.com/camunda-cloud/zeebe/wiki/Release-protocol#update-the-getting-started-guide).