### PR TITLE
Add Kibana to Docker-Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ If docker is available in your system, the `docker-compose.yaml` in the root
 folder can be used to spin up a local environment.
 
 ```
-docker-compose up -d
+docker-compose --profile full up -d
 ```
 
 After this, Zeebe is available under `localhost:26500`. Disable security
@@ -290,3 +290,22 @@ See the following additional resources:
 [Camunda Modeler]: https://camunda.com/download/modeler/
 [Cloud Modeler]: https://docs.camunda.io/docs/product-manuals/modeler/cloud-modeler/launch-cloud-modeler
 [Camunda Cloud Documentation]: https://docs.camunda.io
+
+## Dev setup
+
+The `docker-compose.yaml` uses profiles to configure the environment to your needs.  
+
+Use the default profile to run only Zeebe and Elasticsearch but no web-apps.
+
+```
+docker-compose up -d
+```
+
+Use the `dev` profile to run Zeebe, Elasticsearch and Kibana. Kibana can be used to inspect the data
+that is stored in Elasticsearch.
+
+```
+docker-compose --profile dev up -d
+```
+
+After the services are started, Kibana is available under http://localhost:5601.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,9 @@ services:
             - camunda-cloud
         depends_on:
             - elasticsearch
+        profiles:
+            - webapps
+            - full
 
     tasklist:
         image: camunda/tasklist:${CAMUNDA_CLOUD_VERSION:-1.3.4}
@@ -44,6 +47,9 @@ services:
             - camunda-cloud
         depends_on:
             - elasticsearch
+        profiles:
+            - webapps
+            - full
 
     elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.16.1}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,11 +68,30 @@ services:
         networks:
             - camunda-cloud
 
+    kibana:
+        image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION:-7.16.1}
+        container_name: kibana
+        environment:
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        ports:
+            - 5601:5601
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+        volumes:
+            - kibana:/usr/share/kibana/data
+        networks:
+            - camunda-cloud
+        profiles:
+            - dev
 
 volumes:
     zeebe:
         driver: local
     elastic:
+        driver: local
+    kibana:
         driver: local
 
 networks:


### PR DESCRIPTION
## Description

* Kibana is useful to inspect the data in Elasticsearch
  * use case: manual testing as Zeebe developer
  * enable Kibana if the profile `dev` is set
* introduce profiles for the web apps to avoid that Operate and Tasklist are always started by default
  * enable Operate and Tasklist by one of the profiles: webapps, full 