### PR TITLE
docs(README.md): make docker-compose.yaml a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ components:
 - [Tasklist](https://docs.camunda.io/docs/product-manuals/tasklist/deployment/install-and-start)
 - [Camunda Modeler](https://docs.camunda.io/docs/product-manuals/modeler/camunda-modeler/install-the-modeler)
 
-If docker is available in your system, the `docker-compose.yaml` in the root
+If docker is available in your system, the [docker-compose.yaml](docker-compose.yaml) in the root
 folder can be used to spin up a local environment.
 
 ```


### PR DESCRIPTION
as the context is not clear if one arrives from doc.camunda.io on this page.